### PR TITLE
Fix interceptors

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -351,6 +351,8 @@ const api = createSafeFetch({
       init.headers = headers;
       
       console.log(`→ ${init.method} ${url}`);
+
+      return { input: url, init }
     },
     
     onResponse: (response) => {

--- a/packages/core/README.ru.md
+++ b/packages/core/README.ru.md
@@ -352,6 +352,8 @@ const api = createSafeFetch({
       init.headers = headers;
       
       console.log(`→ ${init.method} ${url}`);
+
+      return { input: url, init }
     },
     
     onResponse: (response) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,7 +105,11 @@ export function createSafeFetch(base: SafeFetchBaseConfig = {}): SafeFetcher {
                 if (init.keepalive) reqInit.keepalive = init.keepalive;
                 if (init.mode) reqInit.mode = init.mode;
 
-                await base.interceptors?.onRequest?.(targetUrl, { ...reqInit, url: targetUrl });
+                const modified = await base.interceptors?.onRequest?.(targetUrl, { ...reqInit, url: targetUrl });
+                if (modified) {
+                    url = modified.input as string;
+                    Object.assign(reqInit, modified.init);
+                }
 
                 const fetchPromise = fetch(targetUrl, reqInit);
                 const abortPromise =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,9 +45,15 @@ export type ValidateResult<T> =
     | { success: false; error: NormalizedError | unknown };
 
 export interface Interceptors {
-    onRequest?: (input: RequestInfo, init: RequestInit & { url: string }) => Promise<void> | void;
-    onResponse?: (response: Response) => Promise<void> | void;
-    onError?: (error: NormalizedError) => Promise<void> | void;
+	onRequest?: (
+		input: RequestInfo,
+		init: RequestInit & { url: string }
+	) =>
+		| Promise<{ input: RequestInfo; init: RequestInit & { url: string } } | void>
+		| { input: RequestInfo; init: RequestInit & { url: string } }
+		| void;
+	onResponse?: (response: Response) => Promise<void> | void;
+	onError?: (error: NormalizedError) => Promise<void> | void;
 }
 
 export type SafeResult<T> =

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -289,4 +289,51 @@ describe('safe-fetch', () => {
             }
         });
     });
+
+    describe('interceptors', () => {
+        it('modifies request in interceptor', async () => {
+            mockFetch.mockResolvedValueOnce(new Response('{"data": "intercepted"}', { status: 200 }));
+
+            const api = createSafeFetch({
+                interceptors: {
+                    onRequest(input, init) {
+                        init.headers = {
+                            ...init.headers,
+                            'X-Custom-Header': 'CustomValue'
+                        };
+                        return { input, init } as any;
+                    }
+                }
+            });
+
+            await api.get('/test');
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'X-Custom-Header': 'CustomValue'
+                    })
+                })
+            );
+        });
+
+        it('intercepts response', async () => {
+            mockFetch.mockResolvedValueOnce(new Response('{"data": "original"}', { status: 200 }));
+
+            let intercepted = false;
+
+            const api = createSafeFetch({
+                interceptors: {
+                    async onResponse(response) {
+                        intercepted = true;
+                    }
+                }
+            });
+
+            await api.get('/test');
+
+            expect(intercepted).toBe(true);
+        });
+    });
 });

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -327,6 +327,12 @@ describe('safe-fetch', () => {
                 interceptors: {
                     async onRequest(input, init) {
                         intercepted = true;
+
+                        // modifying `init` is a no-op
+                        init.headers = {
+                            ...init.headers,
+                            'X-Should-Not-Exist': 'Nope'
+                        };
                     }
                 }
             });
@@ -334,6 +340,14 @@ describe('safe-fetch', () => {
             await api.get('/test');
 
             expect(intercepted).toBe(true);
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.not.objectContaining({
+                    headers: expect.objectContaining({
+                        'X-Should-Not-Exist': 'Nope'
+                    })
+                })
+            );
         });
 
         it('intercepts response', async () => {

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -318,6 +318,24 @@ describe('safe-fetch', () => {
             );
         });
 
+        it('intercepts request without modification correctly', async () => {
+            mockFetch.mockResolvedValueOnce(new Response('{"data": "original"}', { status: 200 }));
+
+            let intercepted = false;
+
+            const api = createSafeFetch({
+                interceptors: {
+                    async onRequest(input, init) {
+                        intercepted = true;
+                    }
+                }
+            });
+
+            await api.get('/test');
+
+            expect(intercepted).toBe(true);
+        });
+
         it('intercepts response', async () => {
             mockFetch.mockResolvedValueOnce(new Response('{"data": "original"}', { status: 200 }));
 


### PR DESCRIPTION
This PR makes onRequest interceptors more flexible and predictable and fixes #6 
- Added tests for interceptors:
- - onRequest:
- - - test interception
- - - test that modifying the arguments of the interceptor is a no-op
- - - test that returning new values for the input url and request init actually alters the request
- - onResponse:
- - - test interception
- Modified onRequest type to support returning void / promise of void (means preserving the original request as-is) and to support returning new values for input and init / promise of input and init (means modifying the request).
- Modified the docs to reflect this feature correctly (it was previously claiming that modifying onRequest args directly does something, which is not the case).